### PR TITLE
Include jq in depends

### DIFF
--- a/depends
+++ b/depends
@@ -19,3 +19,4 @@ lsmod:kmod
 bc
 qemu-nbd:qemu-utils
 kpartx
+jq


### PR DESCRIPTION
Need to include jq in depends. It is used in stage3_homebridge/00-node-install/01-run.sh. It is not necessarily included in base distributions such as Raspberry Pi OS Lite.